### PR TITLE
Connect to the daemon if not already

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.swift]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ on:
     branches: [ master ]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
     - uses: actions/checkout@v2

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,9 +19,9 @@ disabled_rules:
   - file_length
   - function_body_length
   - type_body_length
+  - type_name
 
 opt_in_rules:
-  - anyobject_protocol
   - array_init
   - attributes
   - closure_end_indentation

--- a/Sources/Deluge/Core/Deluge.swift
+++ b/Sources/Deluge/Core/Deluge.swift
@@ -23,6 +23,36 @@ public final class Deluge {
         self.basicAuthentication = basicAuthentication
     }
 
+        /// Attempts to create a `URLRequest` from a `Request`.
+    /// - Parameter request: The request definition to be converted in to a `URLRequest`.
+    /// - Returns: A `Result` containing either the created `URLRequest` or an error if the request was unable to be
+    /// serialized to JSON.
+    private func urlRequest<Value>(from request: Request<Value>) -> Result<URLRequest, DelugeError> {
+        let url = baseURL.appendingPathComponent("json")
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            urlRequest.httpBody = try JSONSerialization.data(withJSONObject: [
+                "id": 1,
+                "method": request.method,
+                "params": request.args,
+            ], options: [])
+        } catch {
+            return .failure(.encoding(error))
+        }
+
+        if let basicAuthentication {
+            urlRequest.setValue("Basic \(basicAuthentication.encoded)", forHTTPHeaderField: "Authorization")
+        }
+
+        return .success(urlRequest)
+    }
+}
+
+/// Combine-powered extensions for `Deluge`.
+extension Deluge {
     /// Sends a request to the server.
     /// - Parameter request: The request to be sent to the server.
     /// - Returns: A publisher that emits a value when the request completes.
@@ -60,37 +90,6 @@ public final class Deluge {
             .eraseToAnyPublisher()
     }
 
-    /// Attempts to create a `URLRequest` from a `Request`.
-    /// - Parameter request: The request definition to be converted in to a `URLRequest`.
-    /// - Returns: A `Result` containing either the created `URLRequest` or an error if the request was unable to be
-    /// serialized to JSON.
-    private func urlRequest<Value>(from request: Request<Value>) -> Result<URLRequest, DelugeError> {
-        let url = baseURL.appendingPathComponent("json")
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        do {
-            urlRequest.httpBody = try JSONSerialization.data(withJSONObject: [
-                "id": 1,
-                "method": request.method,
-                "params": request.args,
-            ], options: [])
-        } catch {
-            return .failure(.encoding(error))
-        }
-
-        if let basicAuthentication {
-            guard let encodedAuthentication = basicAuthentication.encoded else {
-                return .failure(.unauthenticated)
-            }
-
-            urlRequest.setValue("Basic \(encodedAuthentication)", forHTTPHeaderField: "Authorization")
-        }
-
-        return .success(urlRequest)
-    }
-
     /// Attempts to decode a server response in to a dictionary.
     /// - Parameters:
     ///   - data: The data returned from the server.
@@ -114,10 +113,105 @@ public final class Deluge {
                 return Fail(error: .unauthenticated).eraseToAnyPublisher()
             }
 
+            if isTorrentAlreadyAddedException(message: error["message"] as? String) {
+                return Fail(error: .torrentAlreadyAddedException).eraseToAnyPublisher()
+            }
+
             return Fail(error: .serverError(message: error["message"] as? String)).eraseToAnyPublisher()
         }
 
         return Just(dict).setFailureType(to: DelugeError.self).eraseToAnyPublisher()
+    }
+}
+
+/// Swift Concurrency powered extensions for `Deluge`.
+extension Deluge {
+    /// Sends a request to the server.
+    /// - Parameter request: The request to be sent to the server.
+    /// - Returns: A publisher that emits a value when the request completes.
+    public func request<Value>(_ request: Request<Value>) async throws(DelugeError) -> Value {
+        try request.transform(
+            try await send(
+                request: request.prepare(request, self),
+                authenticateIfNeeded: true
+            )
+        ).get()
+    }
+
+    /// Sends a request to the server, optionally handling authentication.
+    ///
+    /// - Parameters:
+    ///   - request: The request to be sent to the server.
+    ///   - authenticateIfNeeded: Whether authentication should be attempted if the server responds that the client is
+    ///   unauthenticated.
+    /// - Returns: A publisher that emits the decoded server response.
+    private func send<Value>(
+        request: Request<Value>,
+        authenticateIfNeeded: Bool
+    ) async throws(DelugeError) -> [String: Any] {
+        do {
+            let (data, response) = try await session.data(for: urlRequest(from: request).get())
+            return try decode(data: data, response: response)
+        } catch let error as DelugeError {
+            guard case .unauthenticated = error, authenticateIfNeeded else {
+                throw error
+            }
+
+            try await self.request(.authenticate)
+            return try await send(request: request, authenticateIfNeeded: false)
+        } catch let error as URLError {
+            throw .request(error)
+        } catch {
+            throw .unknownRequestError(error)
+        }
+    }
+
+    /// Attempts to decode a server response in to a dictionary.
+    /// - Parameters:
+    ///   - data: The data returned from the server.
+    ///   - response: The `URLResponse` describing the server response.
+    /// - Throws: A `DelugeError` if the response is malformed or contains an error.
+    /// - Returns: The decoded dictionary.
+    private func decode(data: Data, response: URLResponse) throws(DelugeError) -> [String: Any] {
+        let dict: [String: Any]
+        do {
+            dict = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] ?? [:]
+        } catch {
+            throw .decoding(error)
+        }
+
+        if let error = dict["error"] as? [String: Any] {
+            if let code = error["code"] as? Int, code == 1 {
+                throw .unauthenticated
+            }
+
+            if isTorrentAlreadyAddedException(message: error["message"] as? String) {
+                throw .torrentAlreadyAddedException
+            }
+
+            throw .serverError(message: error["message"] as? String)
+        }
+
+        return dict
+    }
+
+    private func isTorrentAlreadyAddedException(message: String?) -> Bool {
+        // There is a bug in deluge that adding an already added torrent will return a stacktrace of a python exception...
+        // Yes really... so instead we'll just try to add the same torrents as the combine test and ignore the error
+        // if it looks like the addtorrent exception
+        // https://dev.deluge-torrent.org/ticket/3507
+        guard let message else {
+            return false
+        }
+
+        let parts = [
+            // "<class 'deluge.error.AddTorrentError'>: Torrent already in session",
+            "Torrent already in session",
+            // "<class 'deluge.error.WrappedException'>: type <class 'deluge.error.AddTorrentError'> not handled",
+            "deluge.error.AddTorrentError"
+        ]
+
+        return parts.map { message.contains($0) }.contains(true)
     }
 }
 
@@ -131,10 +225,8 @@ public extension Deluge {
             self.password = password
         }
 
-        var encoded: String? {
-            "\(username):\(password)"
-                .data(using: .utf8)?
-                .base64EncodedString()
+        var encoded: String {
+            Data("\(username):\(password)".utf8).base64EncodedString()
         }
     }
 }

--- a/Sources/Deluge/Core/Deluge.swift
+++ b/Sources/Deluge/Core/Deluge.swift
@@ -196,7 +196,7 @@ extension Deluge {
     }
 
     private func isTorrentAlreadyAddedException(message: String?) -> Bool {
-        // There is a bug in deluge that adding an already added torrent will return a stacktrace of a python exception...
+        // There is a bug in deluge that adding a torrent that exists will return a stacktrace of a python exception...
         // Yes really... so instead we'll just try to add the same torrents as the combine test and ignore the error
         // if it looks like the addtorrent exception
         // https://dev.deluge-torrent.org/ticket/3507

--- a/Sources/Deluge/Core/Deluge.swift
+++ b/Sources/Deluge/Core/Deluge.swift
@@ -23,7 +23,7 @@ public final class Deluge {
         self.basicAuthentication = basicAuthentication
     }
 
-        /// Attempts to create a `URLRequest` from a `Request`.
+    /// Attempts to create a `URLRequest` from a `Request`.
     /// - Parameter request: The request definition to be converted in to a `URLRequest`.
     /// - Returns: A `Result` containing either the created `URLRequest` or an error if the request was unable to be
     /// serialized to JSON.
@@ -129,9 +129,9 @@ extension Deluge {
     /// Sends a request to the server.
     /// - Parameter request: The request to be sent to the server.
     /// - Returns: A publisher that emits a value when the request completes.
-    public func request<Value>(_ request: Request<Value>) async throws(DelugeError) -> Value {
+    public func request<Value>(_ request: Request<Value>) async throws (DelugeError) -> Value {
         try request.transform(
-            try await send(
+            await send(
                 request: request.prepare(request, self),
                 authenticateIfNeeded: true
             )
@@ -148,7 +148,7 @@ extension Deluge {
     private func send<Value>(
         request: Request<Value>,
         authenticateIfNeeded: Bool
-    ) async throws(DelugeError) -> [String: Any] {
+    ) async throws (DelugeError) -> [String: Any] {
         do {
             let (data, response) = try await session.data(for: urlRequest(from: request).get())
             return try decode(data: data, response: response)
@@ -172,7 +172,7 @@ extension Deluge {
     ///   - response: The `URLResponse` describing the server response.
     /// - Throws: A `DelugeError` if the response is malformed or contains an error.
     /// - Returns: The decoded dictionary.
-    private func decode(data: Data, response: URLResponse) throws(DelugeError) -> [String: Any] {
+    private func decode(data: Data, response: URLResponse) throws (DelugeError) -> [String: Any] {
         let dict: [String: Any]
         do {
             dict = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] ?? [:]
@@ -208,7 +208,7 @@ extension Deluge {
             // "<class 'deluge.error.AddTorrentError'>: Torrent already in session",
             "Torrent already in session",
             // "<class 'deluge.error.WrappedException'>: type <class 'deluge.error.AddTorrentError'> not handled",
-            "deluge.error.AddTorrentError"
+            "deluge.error.AddTorrentError",
         ]
 
         return parts.map { message.contains($0) }.contains(true)

--- a/Sources/Deluge/Core/DelugeError.swift
+++ b/Sources/Deluge/Core/DelugeError.swift
@@ -18,4 +18,6 @@ public enum DelugeError: Error {
     case serverError(message: String?)
     /// The server already has this torrent - this is a bug in deluge
     case torrentAlreadyAddedException
+    /// The server is up, but no host is connected
+    case unconnected
 }

--- a/Sources/Deluge/Core/DelugeError.swift
+++ b/Sources/Deluge/Core/DelugeError.swift
@@ -8,10 +8,14 @@ public enum DelugeError: Error {
     case decoding(Error)
     /// A request error occurred.
     case request(URLError)
+    /// An unknown request error occurred.
+    case unknownRequestError(Error)
     /// The provided authentication was not valid.
     case unauthenticated
     /// The server returned an unexpected response.
     case unexpectedResponse
     /// The server returned an error message.
     case serverError(message: String?)
+    /// The server already has this torrent - this is a bug in deluge
+    case torrentAlreadyAddedException
 }

--- a/Sources/Deluge/Models/Host.swift
+++ b/Sources/Deluge/Models/Host.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// A Deluge host
+public struct Host: Equatable {
+    public typealias ID = String
+
+    public let id: ID
+    public let hostURL: URL
+    public let port: Int
+    public let name: String
+
+    public static func == (lhs: Host, rhs: Host) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/Sources/Deluge/Requests/WebRequests.swift
+++ b/Sources/Deluge/Requests/WebRequests.swift
@@ -23,7 +23,12 @@ public extension Request {
         .init(method: "web.get_torrent_files", args: [hash], transform: parseTorrentFilesResponse)
     }
 
-    static func connected() -> Request<Bool> {
+    /// Requests the connection status of the Deluge daemon.
+    ///
+    /// RPC Method: `web.connected`
+    ///
+    /// Result: A boolean indicating whether the Deluge daemon is currently connected.
+    static var connected: Request<Bool> {
         .init(method: "web.connected", args: []) { results in
             if let connected = results["result"] as? Bool {
                 return .success(connected)
@@ -33,10 +38,20 @@ public extension Request {
         }
     }
 
+    /// Requests the list of hosts.
+    ///
+    /// RPC Method: `web.get_hosts`
+    ///
+    /// Result: The list of hosts.
     static var hosts: Request<[Host]> {
         .init(method: "web.get_hosts", args: [], transform: parseHosts)
     }
 
+    /// Connects to a given host.
+    ///
+    /// RPC Method: `web.connect`
+    ///
+    /// - Parameter hostID: The ID of the host to connect to.
     static func connect(to hostID: Host.ID) -> Request<Void> {
         .init(method: "web.connect", args: [hostID])
     }

--- a/Tests/DelugeIntegrationTests/AuthRequestsTests.swift
+++ b/Tests/DelugeIntegrationTests/AuthRequestsTests.swift
@@ -21,4 +21,8 @@ class AuthRequestsTests: IntegrationTestCase {
             .store(in: &cancellables)
         waitForExpectations(timeout: TestConfig.timeout)
     }
+
+    func test_authenticate_concurrency() async throws {
+        try await client.request(.authenticate)
+    }
 }

--- a/Tests/DelugeIntegrationTests/BadMethodTests.swift
+++ b/Tests/DelugeIntegrationTests/BadMethodTests.swift
@@ -28,4 +28,21 @@ class BadMethodTests: IntegrationTestCase {
             .store(in: &cancellables)
         waitForExpectations(timeout: TestConfig.timeout)
     }
+
+    func test_badMethod_concurrency() async throws {
+      let bad = Request<Void>(method: "bad", args: []) { response in
+          XCTFail("Unexpected response: \(String(describing: response))")
+            return .failure(.unexpectedResponse)
+      }
+
+      do {
+        try await client.request(bad)
+        } catch {
+            if case .serverError = error {
+                // success
+            } else {
+                XCTFail("Expected server error")
+            }
+        }
+    }
 }

--- a/Tests/DelugeIntegrationTests/BadMethodTests.swift
+++ b/Tests/DelugeIntegrationTests/BadMethodTests.swift
@@ -30,13 +30,13 @@ class BadMethodTests: IntegrationTestCase {
     }
 
     func test_badMethod_concurrency() async throws {
-      let bad = Request<Void>(method: "bad", args: []) { response in
-          XCTFail("Unexpected response: \(String(describing: response))")
+        let bad = Request<Void>(method: "bad", args: []) { response in
+            XCTFail("Unexpected response: \(String(describing: response))")
             return .failure(.unexpectedResponse)
-      }
+        }
 
-      do {
-        try await client.request(bad)
+        do {
+            try await client.request(bad)
         } catch {
             if case .serverError = error {
                 // success

--- a/Tests/DelugeIntegrationTests/CoreRequestsTests.swift
+++ b/Tests/DelugeIntegrationTests/CoreRequestsTests.swift
@@ -12,7 +12,7 @@ class CoreRequestsTests: IntegrationTestCase {
             .sink(
                 receiveCompletion: { completion in
                     if case let .failure(error) = completion {
-                       XCTFail(String(describing: error))
+                        XCTFail(String(describing: error))
                     }
                     expectation.fulfill()
                 },

--- a/Tests/DelugeIntegrationTests/LabelRequestsTests.swift
+++ b/Tests/DelugeIntegrationTests/LabelRequestsTests.swift
@@ -23,4 +23,10 @@ class LabelRequestsTests: IntegrationTestCase {
             .store(in: &cancellables)
         waitForExpectations(timeout: TestConfig.timeout)
     }
+
+    func test_setLabel_concurrency() async throws {
+        let url = urlForResource(named: TestConfig.torrent1)
+        try await ensureTorrentAdded(fileURL: url, to: client)
+        try await client.request(.setLabel(hash: TestConfig.torrent1Hash, label: ""))
+    }
 }

--- a/Tests/DelugeIntegrationTests/Resources/hash.py
+++ b/Tests/DelugeIntegrationTests/Resources/hash.py
@@ -1,0 +1,9 @@
+import bencoding, hashlib, sys
+
+def torrent_hash(path):
+    file = open(path, 'rb')
+    dictionary = bencoding.bdecode(file.read())
+    info = hashlib.sha1(bencoding.bencode(dictionary[b"info"])).hexdigest()
+    print(info)
+
+torrent_hash(sys.argv[1])

--- a/Tests/DelugeIntegrationTests/SetOptionTests.swift
+++ b/Tests/DelugeIntegrationTests/SetOptionTests.swift
@@ -28,4 +28,13 @@ class SetOptionTests: IntegrationTestCase {
             .store(in: &cancellables)
         waitForExpectations(timeout: TestConfig.timeout)
     }
+
+    func test_filePriorities_concurrency() async throws {
+        let url = urlForResource(named: TestConfig.torrent1)
+        try await ensureTorrentAdded(fileURL: url, to: client)
+        try await client.request(.setOptions(
+            hashes: [TestConfig.torrent1Hash],
+            options: [.filePriorities([.disabled])]
+        ))
+    }
 }

--- a/Tests/DelugeIntegrationTests/TestConfig.swift
+++ b/Tests/DelugeIntegrationTests/TestConfig.swift
@@ -3,7 +3,7 @@ import Foundation
 
 enum TestConfig {
     static var timeout: TimeInterval {
-        ProcessInfo.processInfo.environment["TIMEOUT"].flatMap(TimeInterval.init) ?? 1
+        ProcessInfo.processInfo.environment["TIMEOUT"].flatMap(TimeInterval.init) ?? 2
     }
 
     static let serverURL = URL(string: "http://localhost:8112")!
@@ -18,8 +18,10 @@ enum TestConfig {
     static let torrent2Hash = "2a78414b7af89fe08644ece339ee454867d29cb7"
 
     static let torrent3 = "ubuntu.torrent"
+    static let torrent3Hash = "e2467cbf021192c241367b892230dc1e05c0580e"
 
     static let torrent4 = "fedora.torrent"
+    static let torrent4Hash = "bd2d1a1e1fba6377c0b58aa473b3c86db264a2cd"
 
     // swiftformat:disable indent
     static let magnetURL = """
@@ -30,4 +32,5 @@ enum TestConfig {
     static let magnetHash = "54da0b79719064aa10fe2cc4e13630a1222d1939"
 
     static let webURL = "https://downloads.raspberrypi.org/raspbian_latest.torrent"
+    static let webURLHash = "154091a4c610d1fad2d93648fc0003df95ae6948"
 }

--- a/Tests/DelugeIntegrationTests/TestUtils.swift
+++ b/Tests/DelugeIntegrationTests/TestUtils.swift
@@ -1,6 +1,7 @@
 import Combine
 import Deluge
 import Foundation
+import XCTest
 
 func urlForResource(named resourceName: String) -> URL {
     URL(fileURLWithPath: #file)
@@ -15,4 +16,35 @@ func ensureTorrentAdded(fileURL: URL, to client: Deluge) -> AnyPublisher<Void, D
         .replaceError(with: ())
         .setFailureType(to: DelugeError.self)
         .eraseToAnyPublisher()
+}
+
+// TODO: tests that use this may stomp each other - figure out how to fix that (or switch to swift testing???)
+func ensureTorrentRemoved(hash: String, from client: Deluge) -> AnyPublisher<Void, DelugeError> {
+    client.request(.remove(hashes: [hash], removeData: false))
+        .map { _ in () }
+        .replaceError(with: ())
+        .setFailureType(to: DelugeError.self)
+        .eraseToAnyPublisher()
+}
+
+func ensureTorrentAdded(fileURL: URL, to client: Deluge, file: StaticString = #file, line: UInt = #line) async throws {
+    do {
+        _ = try await client.request(.add(fileURL: fileURL))
+    } catch {
+        switch error {
+        case .torrentAlreadyAddedException:
+            return
+        default:
+            XCTFail(String(describing: error), file: file, line: line)
+        }
+    }
+}
+
+func ensureTorrentRemoved(
+    hash: String,
+    from client: Deluge,
+    file: StaticString = #file,
+    line: UInt = #line
+) async throws {
+    try await client.request(.remove(hashes: [hash], removeData: false))
 }

--- a/Tests/DelugeIntegrationTests/TestUtils.swift
+++ b/Tests/DelugeIntegrationTests/TestUtils.swift
@@ -18,7 +18,7 @@ func ensureTorrentAdded(fileURL: URL, to client: Deluge) -> AnyPublisher<Void, D
         .eraseToAnyPublisher()
 }
 
-// TODO: tests that use this may stomp each other - figure out how to fix that (or switch to swift testing???)
+// When migrated to Swift Testing: tests that use this may stomp each other - figure out how to fix that (or switch to swift testing???)
 func ensureTorrentRemoved(hash: String, from client: Deluge) -> AnyPublisher<Void, DelugeError> {
     client.request(.remove(hashes: [hash], removeData: false))
         .map { _ in () }

--- a/Tests/DelugeIntegrationTests/TestUtils.swift
+++ b/Tests/DelugeIntegrationTests/TestUtils.swift
@@ -18,7 +18,8 @@ func ensureTorrentAdded(fileURL: URL, to client: Deluge) -> AnyPublisher<Void, D
         .eraseToAnyPublisher()
 }
 
-// When migrated to Swift Testing: tests that use this may stomp each other - figure out how to fix that (or switch to swift testing???)
+// When migrated to Swift Testing: tests that use this may stomp each other
+// figure out how to fix that (or switch to swift testing???)
 func ensureTorrentRemoved(hash: String, from client: Deluge) -> AnyPublisher<Void, DelugeError> {
     client.request(.remove(hashes: [hash], removeData: false))
         .map { _ in () }

--- a/Tests/DelugeIntegrationTests/WebRequestsTests.swift
+++ b/Tests/DelugeIntegrationTests/WebRequestsTests.swift
@@ -42,6 +42,31 @@ class WebRequestsTests: IntegrationTestCase {
         waitForExpectations(timeout: TestConfig.timeout)
     }
 
+    func test_updateUI_concurrency() async throws {
+        let url = urlForResource(named: TestConfig.torrent1)
+        try await ensureTorrentAdded(fileURL: url, to: client)
+        let state = try await client.request(.updateUI(properties: Torrent.PropertyKeys.allCases))
+        let torrent = state.torrents.first(where: { $0.hash == TestConfig.torrent1Hash })
+
+        XCTAssertNotNil(torrent?.dateAdded)
+        XCTAssertNotNil(torrent?.downloaded)
+        XCTAssertNotNil(torrent?.downloadPath)
+        XCTAssertNotNil(torrent?.downloadRate)
+        XCTAssertNotNil(torrent?.eta)
+        XCTAssertNotNil(torrent?.label)
+        XCTAssertNotNil(torrent?.name)
+        XCTAssertNotNil(torrent?.peers)
+        XCTAssertNotNil(torrent?.progress)
+        XCTAssertNotNil(torrent?.seeds)
+        XCTAssertNotNil(torrent?.size)
+        XCTAssertNotNil(torrent?.state)
+        XCTAssertNotNil(torrent?.totalPeers)
+        XCTAssertNotNil(torrent?.totalSeeds)
+        XCTAssertEqual(torrent?.trackers, TestConfig.torrent1Trackers)
+        XCTAssertNotNil(torrent?.uploadRate)
+        XCTAssertNotNil(torrent?.uploadRate)
+    }
+
     func test_torrentItems() {
         let url = urlForResource(named: TestConfig.torrent1)
         let expectation = self.expectation(description: #function)
@@ -67,5 +92,18 @@ class WebRequestsTests: IntegrationTestCase {
             )
             .store(in: &cancellables)
         waitForExpectations(timeout: TestConfig.timeout)
+    }
+
+    func test_torrentItems_concurrency() async throws {
+        let url = urlForResource(named: TestConfig.torrent1)
+        try await ensureTorrentAdded(fileURL: url, to: client)
+
+        let items = try await client.request(.torrentItems(hash: TestConfig.torrent1Hash))
+        XCTAssertEqual(items.count, 1)
+        guard case let .file(file) = items.first else {
+            XCTFail("Unexpected item: \(String(describing: items.first))")
+            return
+        }
+        XCTAssertEqual(file.name, TestConfig.torrent1FileName)
     }
 }


### PR DESCRIPTION
This change implements a similar mechanism for 'authenticateIfNeeded' but for connecting a host to the daemon (i.e. if deluge is running but no one has connected via the Web UI).

This is a WIP until I add the requisite tests and determine if this should be handled automatically, throw to the caller to implement (we can have more than one host) or a mix of both. In addition, I think it's getting time to start decoding JSON to `Codable` structs instead of manually extracting things from some `Any` object - but that's a significant rework.